### PR TITLE
fix: fallback to first annotation project if no default exists

### DIFF
--- a/apis_highlighter/templates/apis_highlighter/select_project.html
+++ b/apis_highlighter/templates/apis_highlighter/select_project.html
@@ -1,12 +1,10 @@
 <form>
-  {% with request.GET.highlighter_project|add:"0" as selected_project_id %}
-    <select name="highlighter_project">
-      {% for project in projects %}
-        <option value="{{ project.id }}" 
-          {% if project.id == selected_project_id %}selected="selected"{% endif %}
-          >{{ project }}</option>
-      {% endfor %}
-    </select>
-    <input type="submit" value="Submit">
-  {% endwith %}
+  <select name="highlighter_project">
+    {% for project in projects %}
+      <option value="{{ project.id }}" 
+        {% if project.id == project_id %}selected="selected"{% endif %}
+        >{{ project }}</option>
+    {% endfor %}
+  </select>
+  <input type="submit" value="Submit">
 </form>

--- a/apis_highlighter/templatetags/apis_highlighter.py
+++ b/apis_highlighter/templatetags/apis_highlighter.py
@@ -16,7 +16,11 @@ def overlap(range_one, range_two) -> bool:
 @register.filter()
 def highlight_text(obj, request=None, fieldname="text", project_id=None):
     if project_id is None:
-        default_project = getattr(settings, "DEFAULT_HIGHLIGTHER_PROJECT", None)
+        default_project = getattr(
+            settings,
+            "DEFAULT_HIGHLIGTHER_PROJECT",
+            AnnotationProject.objects.first().id,
+        )
         project_id = request.GET.get("highlighter_project", default_project)
 
     ct = ContentType.objects.get_for_model(obj)
@@ -76,4 +80,12 @@ def highlight_text(obj, request=None, fieldname="text", project_id=None):
 
 @register.inclusion_tag("apis_highlighter/select_project.html")
 def select_highlighter_project(request):
-    return {"request": request, "projects": AnnotationProject.objects.all()}
+    default_project = getattr(
+        settings, "DEFAULT_HIGHLIGTHER_PROJECT", AnnotationProject.objects.first().id
+    )
+    project_id = request.GET.get("highlighter_project", default_project)
+    return {
+        "request": request,
+        "projects": AnnotationProject.objects.all(),
+        "project_id": project_id,
+    }


### PR DESCRIPTION
If DEFAULT_HIGHLIGTHER_PROJECT is not set, we use the first annotation
project as a default.
