### PR TITLE
fix: delete view

### DIFF
--- a/apis_highlighter/static/js/highlighter.js
+++ b/apis_highlighter/static/js/highlighter.js
@@ -116,7 +116,7 @@ function annotation_menu(element) {
   var menu = document.createElement("div");
   menu.classList.add("highlighter-annotation-menu");
   var dela = document.createElement("a");
-  dela.href = element.dataset.delete;
+  dela.href = element.dataset.delete +"?to=" + window.location.pathname + window.location.search;
   dela.innerHTML = "Delete";
   menu.appendChild(dela);
   $(element).popover({content: menu, html: true});

--- a/apis_highlighter/templates/apis_highlighter/annotation_confirm_delete.html
+++ b/apis_highlighter/templates/apis_highlighter/annotation_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends basetemplate %}
+{% extends basetemplate|default:"base.html" %}
 
 {% block content %}
   <div class="modal-dialog">

--- a/apis_highlighter/views.py
+++ b/apis_highlighter/views.py
@@ -33,6 +33,11 @@ class AnnotationDelete(DeleteView):
     def get_template_names(self):
         return ["confirm_delete", "apis_highlighter/annotation_confirm_delete.html"]
 
+    def get_success_url(self):
+        if redirect_to := self.request.GET.get("to", False):
+            return redirect_to
+        return super().get_success_url()
+
 
 # wrapper around the `save_ajax_form` method from apis_relations.views
 # this lets us create the annotation while creating the relation


### PR DESCRIPTION
The delete view did not have a fallback template set as well as no
success_url - we do now redirect to the `?to=` argument, if given.
