### PR TITLE
fix: make signal more robust

### DIFF
--- a/apis_highlighter/signals.py
+++ b/apis_highlighter/signals.py
@@ -5,21 +5,24 @@ from django.contrib.contenttypes.models import ContentType
 from .models import Annotation
 from .helpers import correlate_annotations
 
+APP_LABEL_EXCLUDE = ["admin", "auth", "sessions", "apis_highlighter"]
+
 
 @receiver(pre_save)
 def update_annotations_offsets(sender, instance, raw, using, update_fields, **kwargs):
-    if sender is Annotation:
-        return
-    if instance.id:
-        content_type = ContentType.objects.get_for_model(instance)
-        annotations = Annotation.objects.filter(
-            text_content_type=content_type, text_object_id=instance.id
-        ).order_by("start")
-        if annotations:
-            oldtext = sender.objects.get(id=instance.id).text
-            if oldtext != instance.text:
-                correlate_annotations(
-                    text_old=oldtext,
-                    text_new=instance.text,
-                    annotations_old=annotations,
-                )
+    meta = getattr(sender, "_meta", {})
+    app_label = getattr(meta, "app_label", "apis_highlighter")
+    if app_label not in APP_LABEL_EXCLUDE:
+        if getattr(instance, "id", False):
+            content_type = ContentType.objects.get_for_model(instance)
+            annotations = Annotation.objects.filter(
+                text_content_type=content_type, text_object_id=instance.id
+            ).order_by("start")
+            if annotations:
+                oldtext = sender.objects.get(id=instance.id).text
+                if oldtext != instance.text:
+                    correlate_annotations(
+                        text_old=oldtext,
+                        text_new=instance.text,
+                        annotations_old=annotations,
+                    )


### PR DESCRIPTION
The signal should not fail, if the instance does not have an `id`
attribute.
