### PR TITLE
refactor: dump jquery and popover and implement custom movable popover

### DIFF
--- a/apis_highlighter/static/css/highlighter.css
+++ b/apis_highlighter/static/css/highlighter.css
@@ -10,6 +10,18 @@
 .select2-container--open {
     z-index: 9999999
 }
-.popover{
-    max-width: 100%;
+#highlighterpopup {
+  cursor: move;
+  min-width: 200px;
+  background-color: white;
+  padding: 1em;
+  border: 1px solid black;
+  position: absolute;
+  display: none;
+}
+#highlightermenu {
+  display: none;
+}
+.highlighter-menu-item {
+  cursor: pointer;
 }

--- a/apis_highlighter/templates/apis_highlighter/apis_highlighter.html
+++ b/apis_highlighter/templates/apis_highlighter/apis_highlighter.html
@@ -1,0 +1,19 @@
+<link itemprop="url" rel="stylesheet" href="/static/css/highlighter.css">
+<span class="text-danger" id="highlightermarker"></span>
+<div class="popup" id="highlighterpopup"></div>
+<div id="highlightermenu">
+  <h4>Create annotation:</h4>
+  <div class="btn btn-primary btn-block highlighter-menu-item"
+       data-rel="person_to_place">Person to Place</div>
+  <div class="btn btn-primary btn-block highlighter-menu-item"
+       data-rel="person_to_institution">Person to Institution</div>
+  <div class="btn btn-primary btn-block highlighter-menu-item"
+       data-rel="person_to_person">Person to Person</div>
+</div>
+<input id="hiddeninput" type="hidden" name="annotationdata">
+</input>
+<div id="highlighter-annotation-menu">
+  <div id="header"></div>
+  <a id="delbtn" class="btn btn-danger">Delete</a>
+</div>
+<script src="/static/js/highlighter.js"></script>


### PR DESCRIPTION
This commit refactors the whole `highlighter.js` javascript. The
highlighter app now ships a template `apis_highlighter.html` that should
be included to use highlighter. This template contains skeleton html
elements which are then used by `highlighter.js` to show the highlighter
elements.
Both the `highlighter.js` and the `highlighter.css` file are now loaded
by the `apis_highlighter.html` template, so users don't have to include
multiple files.
The `highlighter.js` now does not use any jquery functions anymore and
it includes a method that makes the overlays movable.
