### PR TITLE
fix(templates): make the selection menu reflect the selected value

### DIFF
--- a/apis_highlighter/templates/apis_highlighter/select_project.html
+++ b/apis_highlighter/templates/apis_highlighter/select_project.html
@@ -2,7 +2,7 @@
   <select name="highlighter_project">
     {% for project in projects %}
       <option value="{{ project.id }}" 
-        {% if project.id == project_id %}selected="selected"{% endif %}
+        {% if project.id == project_id|add:"0" %}selected{% endif %}
         >{{ project }}</option>
     {% endfor %}
   </select>


### PR DESCRIPTION
No value was marked as selected because we compared an int with an
string. Adding '0' to the string seems to be the standard way of casting
in Django templates. Doing that makes the comparison work.
