### PR TITLE
feat: store the selected annotation project in the session

### DIFF
--- a/apis_highlighter/helpers.py
+++ b/apis_highlighter/helpers.py
@@ -2,6 +2,10 @@ import logging
 import re
 from math import inf
 
+from apis_highlighter.models import AnnotationProject
+
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -83,3 +87,22 @@ def correlate_annotations(text_old, text_new, annotations_old):
             ann.save()
         else:
             ann.delete()  # TODO: we might want to delete relations as well.
+
+
+def get_annotation_project(request=None):
+    if request is not None:
+        if selected_project := request.GET.get("highlighter_project"):
+            if hasattr(request, "session"):
+                request.session["apis_highlighter_project_id"] = selected_project
+            return selected_project
+
+    default_project = getattr(
+        settings,
+        "DEFAULT_HIGHLIGTHER_PROJECT",
+        AnnotationProject.objects.first().id,
+    )
+
+    if hasattr(request, "session"):
+        return request.session.get("apis_highlighter_project_id", default_project)
+
+    return default_project

--- a/apis_highlighter/views.py
+++ b/apis_highlighter/views.py
@@ -19,17 +19,12 @@ class AnnotationsView(View):
         ct = ContentType.objects.get_for_id(text_content_type)
         # return 404 if not exist
         self.object = ct.get_object_for_this_type(pk=text_object_id)
-        self.project_id = kwargs.get("project_id")
         self.field_name = kwargs.get("text_field_name")
 
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        return HttpResponse(
-            highlight_text(
-                self.object, field_name=self.field_name, project_id=self.project_id
-            )
-        )
+        return HttpResponse(highlight_text(self.object, field_name=self.field_name))
 
 
 class AnnotationDelete(DeleteView):


### PR DESCRIPTION
This commit refactors getting the selected annotation project into a
helper function. This function now also checks in the session if there
is an annotation project defined. If no project is defined in the
session, but there is one selected via request params, that one is
stored in the session.

Closes: #49 