### PR TITLE
fix(dependencies): loosen Django version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-Django = "^4.1"
+Django = ">4.1"
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
This allows the coexistence in installations with Django 5.x
