### PR TITLE
fix(view): pass request to `highlight_text`

### DIFF
--- a/apis_highlighter/views.py
+++ b/apis_highlighter/views.py
@@ -26,7 +26,9 @@ class AnnotationsView(View):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        return HttpResponse(highlight_text(self.object, field_name=self.field_name))
+        return HttpResponse(
+            highlight_text(self.object, request=request, field_name=self.field_name)
+        )
 
 
 class AnnotationDelete(DeleteView):


### PR DESCRIPTION
without the request the `highlight_text` has no way of finding out which
project is the one it should be using.
