### PR TITLE
feat(urls): drop separate `annotations` route

### DIFF
--- a/apis_highlighter/templatetags/apis_highlighter.py
+++ b/apis_highlighter/templatetags/apis_highlighter.py
@@ -25,7 +25,6 @@ def highlight_text(obj, request=None, field_name="text"):
     args = [ct.id, obj.id, field_name]
     if project_id:
         annotations = annotations.filter(project__id=project_id)
-        args.append(project_id)
 
     annotations_url = reverse("apis_highlighter:annotations", args=args)
     prefix = (

--- a/apis_highlighter/urls.py
+++ b/apis_highlighter/urls.py
@@ -11,11 +11,6 @@ urlpatterns = [
         name="annotations",
     ),
     path(
-        "annotations/<text_content_type>/<text_object_id>/<text_field_name>/<project_id>",
-        views.AnnotationsView.as_view(),
-        name="annotations",
-    ),
-    path(
         "annotation/<int:pk>/delete",
         views.AnnotationDelete.as_view(),
         name="annotationdelete",


### PR DESCRIPTION
The project_id is now stored in a session variable. Therefore we don't
need to pass it to the view as an argument (and it wasn't passed on
anyway).
